### PR TITLE
prepared for cmake subproject build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,19 @@ endif()
 
 set(SOURCE "src/main.c")
 
-include_directories("../umurmur/src")
+if(UMURMUR_ROOT_PATH)
+  include_directories("${UMURMUR_ROOT_PATH}/src")
+else()
+  if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/../umurmur/CMakeLists.txt")
+    include_directories("../umurmur/src")
+  else()
+    message(FATAL_ERROR "Could not determine the umurmur source path. Please specify UMURMUR_ROOT_PATH")
+  endif()
+endif()
+
+if(UMURMUR_BINARY_DIR)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${UMURMUR_BINARY_DIR})
+endif()
 
 add_executable(umurmur-monitor ${SOURCE})
 target_link_libraries(umurmur-monitor ${LIBRT})


### PR DESCRIPTION
A user might either use the git subproject approach or he/she might
clone umurmur and umurmur-monitor side-by-side like so:

  some_base_dir
        |
        +-> umurmur
        +-> umurmur-monitor

This allows umurmur-monitor to find the umurmur headers needed to build
the project. If for some reason none of the above choices is
acceptable, the user might specify UMURMUR_ROOT_PATH like so:

  cmake -DUMURMUR_ROOT_PATH=/path/to/source/of/umurmur <other_args>

and build umurmur-monitor separately from umurmur.
